### PR TITLE
商品削除機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit]
-  before_action :set_item, only: [:edit, :show, :update,]
-  before_action :move_to_index, only: [:edit]
+  before_action :set_item, only: [:edit, :show, :update]
+  before_action :move_to_index, only: [:edit, :destroy]
   # 出品時にログインしていない場合はログイン画面に推移する
   # edit show updateの実行前にset_itemを実行する
   # 出品者以外がログインしている際はmove_to_indexを実行する
@@ -34,6 +34,12 @@ class ItemsController < ApplicationController
       redirect_to item_path(@item.id) 
     else
       render :edit
+    end
+  end
+
+  def destroy
+    if set_item.destroy
+      redirect_to root_path
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit]
-  before_action :set_item, only: [:edit, :show, :update]
-  before_action :move_to_index, only: [:edit, :destroy]
+  before_action :set_item, only: [:edit, :show, :update, :destroy]
+  before_action :move_to_index, only: [:edit]
   # 出品時にログインしていない場合はログイン画面に推移する
   # edit show updateの実行前にset_itemを実行する
   # 出品者以外がログインしている際はmove_to_indexを実行する
@@ -38,7 +38,8 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    if set_item.destroy
+    if user_signed_in? && current_user.id == set_item.user_id
+      set_item.destroy
       redirect_to root_path
     end
   end
@@ -54,7 +55,7 @@ class ItemsController < ApplicationController
   end
 
   def move_to_index
-    unless current_user.id ==  set_item.user_id
+    unless current_user.id == set_item.user_id
       redirect_to root_path
     end
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -40,8 +40,8 @@ class ItemsController < ApplicationController
   def destroy
     if current_user.id == set_item.user_id
       @item.destroy
-      redirect_to root_path
     end
+    redirect_to root_path
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -38,8 +38,8 @@ class ItemsController < ApplicationController
   end
 
   def destroy
-    if user_signed_in? && current_user.id == set_item.user_id
-      set_item.destroy
+    if current_user.id == set_item.user_id
+      @item.destroy
       redirect_to root_path
     end
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,9 +1,9 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :edit]
+  before_action :authenticate_user!, only: [:new, :edit, :destroy]
   before_action :set_item, only: [:edit, :show, :update, :destroy]
   before_action :move_to_index, only: [:edit]
   # 出品時にログインしていない場合はログイン画面に推移する
-  # edit show updateの実行前にset_itemを実行する
+  # edit show update destroyの実行前にset_itemを実行する
   # 出品者以外がログインしている際はmove_to_indexを実行する
   
   def index

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,7 @@
       <% if current_user.id == @item.user_id %>
         <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
-        <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
+        <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
       <% else %>
         <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: "items#index"
-  resources :items, only: [:index, :new, :create, :show, :edit, :update]
-
+  resources :items
+  #すべてのアクションにルーティング設定
 end


### PR DESCRIPTION
# What
ルーティング（destroyアクション）
削除ボタン実装
destroyアクション定義
削除後にトップページに戻る
# Why
削除ボタンにパラマメーターの値を引き渡す
ログイン状態の場合にのみ、自身が出品した商品情報を削除できるようにするため
削除が完了したらトップページに戻すため

URL
ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画
https://gyazo.com/978164f50f1e7e3a50256abf9148861b